### PR TITLE
Execute bit and similar permissions problems prevent proper operation and decrease security.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN \
   apt install git -y
 
 RUN \
-  addgroup --gid $USER_ID $USER_NAME && \
+  addgroup --disabled-password --gid $USER_ID $USER_NAME && \
   adduser --disabled-password --home $HOME_DIR --uid $USER_ID --gid $USER_ID $USER_NAME
 
 USER $USER_NAME
@@ -64,20 +64,22 @@ RUN \
   apt install git -y
 
 RUN \
-  addgroup --gid $USER_ID $USER_NAME && \
+  addgroup --disabled-password --gid $USER_ID $USER_NAME && \
   adduser --disabled-password --home $HOME_DIR --uid $USER_ID --gid $USER_ID $USER_NAME
-
-RUN \
-  mkdir /usr/local/vivo && \
-  mkdir /usr/local/vivo/home && \
-  chown -R $USER_ID:$USER_ID /usr/local/vivo /usr/local/tomcat
-
-USER $USER_NAME
 
 COPY --from=maven $HOME_DIR/VIVO/installer/home/target/vivo /vivo-home
 COPY --from=maven $HOME_DIR/VIVO/installer/webapp/target/vivo.war /usr/local/tomcat/webapps/$BASE_PATH.war
 
 COPY start.sh /start.sh
+
+RUN \
+  mkdir -p /usr/local/vivo/home && \
+  chown -R $USER_ID:$USER_ID /usr/local/vivo /usr/local/tomcat /vivo-home /usr/local/tomcat/webapps/$BASE_PATH.war && \
+  chmod -R u+rwx,go+r-wx /usr/local/tomcat/webapps/$BASE_PATH.war && \
+  chmod -R ugo+X /usr/local/tomcat/webapps/$BASE_PATH.war && \
+  chmod go-w,ugo+rx /start.sh
+
+USER $USER_NAME
 
 EXPOSE 8080
 


### PR DESCRIPTION
Docker is not as isolated as it could otherwise be. Different hosts will set different file bits on repository checkout.

The start.sh script, when copied on a Linux will likely not have execute bit set (which is good for security reasons). On hosts like Windows, the execute bit might be set.

Make sure the required bits are set.
Also remove the write bit for safety reasons as well.

File permissions should probably be manually adjusted for all files COPY'd over for this reason. This can be more complicated as some files might need to be executable and others not.

The `--from=maven` means that the permissions are being assigned from another Docker setup. Just trust that for now.
Preliminary review suggests that there are potential permissions problems with world writable bits set on some files. This may or may not be intentional and is therefore left alone.

Make sure `addgroup` doesn't have password generated just like with `adduser`.

The files COPY'd over are copied as the source user and the `chmod` and similar commands will probably fail. Relocate the directory setup commands to under the root user to ensure access is allowed. Then properly correct all permissions and switch to the non-root user.

Move all of the manipulate commands into a single RUN for a hopefully cleaner design. Simplify the `mkdir` command by adding `-p` which results in automatically creating parent directories if they are missing.

The `/start.sh` does not need to be owned by the `$USER_NAME` for execution. This makes the process more secure in that some process cannot alter the start script during the runtime of the container. This prevents the user from altering the image so that docker restarts/re-runs do not initiate a modified start script.